### PR TITLE
Feat/chat&translation

### DIFF
--- a/src/app/pages/ActiveMeeting.tsx
+++ b/src/app/pages/ActiveMeeting.tsx
@@ -365,35 +365,25 @@ function ActiveMeetingContent({
         const sourceLang = sourceLangRaw === 'ja' || sourceLangRaw.toLowerCase().includes('ja') ? 'ja' :
           sourceLangRaw === 'ko' || sourceLangRaw.toLowerCase().includes('ko') ? 'ko' : 'unknown';
 
-        // Get user's language preference (normalize to 'ja' or 'ko')
-        const userLang = systemLanguage === 'ja' ? 'ja' :
-          systemLanguage === 'ko' ? 'ko' :
-            (systemLanguage?.toLowerCase().includes('ja') ? 'ja' : 'ko');
-
-        // Only show translations from languages the user doesn't speak
-        if (sourceLang === userLang) {
-          console.log('🔇 Skipping STT - user speaks this language:', sourceLang);
-          return; // Skip - user already understands this language
-        }
-
         // Extract original and translated text
         const speaker = sttData.display_name || 'Unknown';
         const originalText = sttData.text || '';
         const translatedText = sttData.translated_text || '';
 
-        if (!originalText || !translatedText) {
-          console.log('⚠️ STT missing text or translation');
+        if (!originalText) {
+          console.log('⚠️ STT missing text');
           return;
         }
 
         // Add to translation logs for the translation panel
+        // Show all STT messages (including own speech) so user can see how their speech is translated
         setTranslationLogs(prev => [
           ...prev,
           {
             id: sttData.id || Date.now().toString(),
             speaker,
             originalText,
-            translatedText,
+            translatedText: translatedText || '(翻訳中...)', // Show placeholder if translation not ready
             originalLang: sourceLang as 'ja' | 'ko',
             timestamp: new Date(sttData.created_at || Date.now())
           }


### PR DESCRIPTION
Fix: Chat & Translation Features
1. What did you do?
Implemented and improved the display functionality for real-time speech-to-text (STT) translation messages.

Key changes:

Added a handler to process messages received via WebSocket with type: "stt".

Implemented functionality to display STT translation messages in the Translation Logs panel.

Removed language filters so that the user's own speech is displayed along with its translation.

Improved the translation display for chat messages by correctly processing the translated_text field.

2. How did you do it?
File: src/app/pages/ActiveMeeting.tsx
Change 1: Added type: "stt" message handler (Lines 357-402)
Implemented logic to normalize source languages (mapping variations of "ja" and "ko"), extract the speaker's name, and push the data into the translationLogs state. Included a "(Translating...)" placeholder for cases where the translation might be slightly delayed.

Change 2: Chat message translation display (Lines 240-273)
Updated the chat handler to compare the message language with the systemLanguage. If they differ and a translation exists, the translation field is populated to show the translated text below the original message.

Change 3: Updated useEffect dependency array (Line 425)
Added systemLanguage to the dependency array to ensure the WebSocket listener updates correctly when the user changes their language settings.

3. How was it tested?
Testing Methods
WebSocket Verification (Browser DevTools):

Monitored the Console tab for:

🎤 STT message received: (Successful data reception)

✅ Added STT translation to panel: (State update success)

📨 Chat message received: (Standard chat flow)

UI Verification (Translation Panel):

Joined a meeting and confirmed that spoken words appear in the panel with both original and translated text.

Verified that the user’s own speech is visible to confirm what others are seeing.

Chat Functionality:

Sent messages in one language and verified the translated text appeared below the message for users with a different system language.


4. Notes for reviewers
⚠️ Dependencies
This frontend update requires the following backend changes to function correctly:

WebSocket broadcasts must use the type: "stt" format.

Payloads must include translated_text and translated_lang fields.

Proper relay of STT translation events via Redis.

📝 Design Decisions
Displaying own speech: This allows users to verify "how they are being translated" to others, which is crucial for clarity and debugging.

Fallback Mechanism: Used a "(Translating...)" placeholder to handle potential network latency between the STT and the translation completion.

Language Normalization: Added robust parsing for language codes (e.g., converting jp, Japanese, or ja consistently to ja) to handle inconsistencies in backend data.

🔍 Review Checklist
[ ] Verify WebSocket message type is strictly "stt".

[ ] Confirm translated_text fields are mapped correctly in the state.

[ ] Ensure the Translation Panel UI renders without performance lag during rapid speech.