### PR TITLE
[FIX] don't look Uri-Tomo

### DIFF
--- a/src/app/pages/Minutes.tsx
+++ b/src/app/pages/Minutes.tsx
@@ -132,12 +132,19 @@ export function Minutes() {
         decisions: [],
       };
 
-      // Ensure participants array exists and is properly formatted
-      const participants = (meeting.participants || []).map((p: any) => ({
-        id: p.id || String(Math.random()),
-        name: p.name || 'Unknown',
-        language: p.language,
-      }));
+      // Ensure participants array exists and is properly formatted, filtering out system participants
+      const participants = (meeting.participants || [])
+        .filter((p: any) => {
+          const name = (p.name || '').toLowerCase();
+          const id = (p.id || '').toLowerCase();
+          return !name.includes('worker') && !name.includes('livekit') &&
+            !id.includes('worker') && !id.includes('livekit');
+        })
+        .map((p: any) => ({
+          id: p.id || String(Math.random()),
+          name: p.name || 'Unknown',
+          language: p.language,
+        }));
 
       setMinutes({
         id: meeting.id,


### PR DESCRIPTION
> **What did you do？**
We fixed the issue where worker:livekit_worker was displayed to members and the number of participants wasn't being counted correctly.

> **How did you do it？**
System Participant Determination Logic: Define system participants as those containing “worker” or “livekit” in either identity or name, and filter accordingly (case-insensitive).